### PR TITLE
Initial working MultiTenantCMSManager with 3 basic tests

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import org.apache.lucene.index.MultiTenantCMSManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -116,7 +117,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
   protected CachedExecutor intraMergeExecutor;
 
   /** Sole constructor, with all settings set to default values. */
-  public ConcurrentMergeScheduler() {}
+  public ConcurrentMergeScheduler() {
+    MultiTenantCMSManager.getInstance().register(this);
+  }
 
   /**
    * Expert: directly set the maximum number of merge threads and simultaneous merges allowed.
@@ -465,6 +468,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
 
   @Override
   public void close() throws IOException {
+    MultiTenantCMSManager.getInstance().unregister(this);
     super.close();
     try {
       sync();

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -18,7 +18,6 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import org.apache.lucene.index.MultiTenantCMSManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
@@ -20,8 +20,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.lucene.index.ConcurrentMergeScheduler;
-
 /**
  * Simple demonstration of a MultiTenantCMSManager that divides a fixed thread budget equally among
  * all registered ConcurrentMergeSchedulers.
@@ -37,26 +35,26 @@ public class MultiTenantCMSManager {
 
   private MultiTenantCMSManager() {}
 
-/**
- * Returns the singleton instance of the MultiTenantCMSManager.
- */
+  /** Returns the singleton instance of the MultiTenantCMSManager. */
   public static MultiTenantCMSManager getInstance() {
     return INSTANCE;
   }
-/**
- * Registers a ConcurrentMergeScheduler with the global manager.
- *
- * @param cms the merge scheduler to register
- */
+
+  /**
+   * Registers a ConcurrentMergeScheduler with the global manager.
+   *
+   * @param cms the merge scheduler to register
+   */
   public void register(ConcurrentMergeScheduler cms) {
     schedulers.add(cms);
     updateBudgets();
   }
-/**
- * Unregisters a ConcurrentMergeScheduler from the global manager.
- *
- * @param cms the merge scheduler to unregister
- */
+
+  /**
+   * Unregisters a ConcurrentMergeScheduler from the global manager.
+   *
+   * @param cms the merge scheduler to unregister
+   */
   public void unregister(ConcurrentMergeScheduler cms) {
     schedulers.remove(cms);
     updateBudgets();

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
@@ -1,0 +1,59 @@
+package org.apache.lucene.index;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Simple demonstration of a MultiTenantCMSManager that divides a fixed thread budget
+ * equally among all registered ConcurrentMergeSchedulers.
+ */
+public class MultiTenantCMSManager {
+
+    private static final MultiTenantCMSManager INSTANCE = new MultiTenantCMSManager();
+    private static final int coreCount = Runtime.getRuntime().availableProcessors();
+    private static final int maxThreadCount = Math.max(1, coreCount / 2);
+
+    private final Set<ConcurrentMergeScheduler> schedulers =
+        Collections.synchronizedSet(new HashSet<>());
+
+    private MultiTenantCMSManager() {}
+
+    public static MultiTenantCMSManager getInstance() {
+        return INSTANCE;
+    }
+
+    public void register(ConcurrentMergeScheduler cms) {
+        schedulers.add(cms);
+        updateBudgets();
+    }
+
+    public void unregister(ConcurrentMergeScheduler cms) {
+        schedulers.remove(cms);
+        updateBudgets();
+    }
+
+    private void updateBudgets() {
+        int count = schedulers.size();
+        if (count == 0) return;
+
+        int share = Math.max(1, maxThreadCount / count);
+        for (ConcurrentMergeScheduler cms : schedulers) {
+            cms.setMaxMergesAndThreads(share + 5, share); // +5 to allow merge queuing
+        }
+    }
+
+    // -----------------------------------------
+    // 🧪 TESTING HOOKS
+    // -----------------------------------------
+
+    /** Used in tests to read the current registered CMS set */
+    synchronized Set<ConcurrentMergeScheduler> getRegisteredSchedulersForTest() {
+        return new HashSet<>(schedulers);
+    }
+
+    /** Used in tests to clear all registered CMS instances */
+    synchronized void unregisterAllForTest() {
+        schedulers.clear();
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+
 /**
  * Simple demonstration of a MultiTenantCMSManager that divides a fixed thread budget equally among
  * all registered ConcurrentMergeSchedulers.
@@ -35,15 +37,26 @@ public class MultiTenantCMSManager {
 
   private MultiTenantCMSManager() {}
 
+/**
+ * Returns the singleton instance of the MultiTenantCMSManager.
+ */
   public static MultiTenantCMSManager getInstance() {
     return INSTANCE;
   }
-
+/**
+ * Registers a ConcurrentMergeScheduler with the global manager.
+ *
+ * @param cms the merge scheduler to register
+ */
   public void register(ConcurrentMergeScheduler cms) {
     schedulers.add(cms);
     updateBudgets();
   }
-
+/**
+ * Unregisters a ConcurrentMergeScheduler from the global manager.
+ *
+ * @param cms the merge scheduler to unregister
+ */
   public void unregister(ConcurrentMergeScheduler cms) {
     schedulers.remove(cms);
     updateBudgets();

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
@@ -5,55 +5,55 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Simple demonstration of a MultiTenantCMSManager that divides a fixed thread budget
- * equally among all registered ConcurrentMergeSchedulers.
+ * Simple demonstration of a MultiTenantCMSManager that divides a fixed thread budget equally among
+ * all registered ConcurrentMergeSchedulers.
  */
 public class MultiTenantCMSManager {
 
-    private static final MultiTenantCMSManager INSTANCE = new MultiTenantCMSManager();
-    private static final int coreCount = Runtime.getRuntime().availableProcessors();
-    private static final int maxThreadCount = Math.max(1, coreCount / 2);
+  private static final MultiTenantCMSManager INSTANCE = new MultiTenantCMSManager();
+  private static final int coreCount = Runtime.getRuntime().availableProcessors();
+  private static final int maxThreadCount = Math.max(1, coreCount / 2);
 
-    private final Set<ConcurrentMergeScheduler> schedulers =
-        Collections.synchronizedSet(new HashSet<>());
+  private final Set<ConcurrentMergeScheduler> schedulers =
+      Collections.synchronizedSet(new HashSet<>());
 
-    private MultiTenantCMSManager() {}
+  private MultiTenantCMSManager() {}
 
-    public static MultiTenantCMSManager getInstance() {
-        return INSTANCE;
+  public static MultiTenantCMSManager getInstance() {
+    return INSTANCE;
+  }
+
+  public void register(ConcurrentMergeScheduler cms) {
+    schedulers.add(cms);
+    updateBudgets();
+  }
+
+  public void unregister(ConcurrentMergeScheduler cms) {
+    schedulers.remove(cms);
+    updateBudgets();
+  }
+
+  private void updateBudgets() {
+    int count = schedulers.size();
+    if (count == 0) return;
+
+    int share = Math.max(1, maxThreadCount / count);
+    for (ConcurrentMergeScheduler cms : schedulers) {
+      cms.setMaxMergesAndThreads(share + 5, share); // +5 to allow merge queuing
     }
+  }
 
-    public void register(ConcurrentMergeScheduler cms) {
-        schedulers.add(cms);
-        updateBudgets();
-    }
+  // -----------------------------------------
+  // 🧪 TESTING HOOKS
+  // -----------------------------------------
 
-    public void unregister(ConcurrentMergeScheduler cms) {
-        schedulers.remove(cms);
-        updateBudgets();
-    }
+  /** Used in tests to read the current registered CMS set */
+  synchronized Set<ConcurrentMergeScheduler> getRegisteredSchedulersForTest() {
+    return new HashSet<>(schedulers);
+  }
 
-    private void updateBudgets() {
-        int count = schedulers.size();
-        if (count == 0) return;
-
-        int share = Math.max(1, maxThreadCount / count);
-        for (ConcurrentMergeScheduler cms : schedulers) {
-            cms.setMaxMergesAndThreads(share + 5, share); // +5 to allow merge queuing
-        }
-    }
-
-    // -----------------------------------------
-    // 🧪 TESTING HOOKS
-    // -----------------------------------------
-
-    /** Used in tests to read the current registered CMS set */
-    synchronized Set<ConcurrentMergeScheduler> getRegisteredSchedulersForTest() {
-        return new HashSet<>(schedulers);
-    }
-
-    /** Used in tests to clear all registered CMS instances */
-    synchronized void unregisterAllForTest() {
-        schedulers.clear();
-    }
+  /** Used in tests to clear all registered CMS instances */
+  synchronized void unregisterAllForTest() {
+    schedulers.clear();
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.index;
 
 import java.util.Collections;

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiTenantCMSManager.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiTenantCMSManager.java
@@ -1,0 +1,97 @@
+package org.apache.lucene.index;
+
+import static org.junit.Assert.*;
+
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Smoke-tests MultiTenantCMSManager’s register/unregister + budget math
+ */
+public class TestMultiTenantCMSManager {
+
+    private MultiTenantCMSManager mgr;
+
+    /**
+     * A dummy CMS that just remembers the last values passed to
+     * setMaxMergesAndThreads(...)
+     */
+    static class DummyCMS extends ConcurrentMergeScheduler {
+        volatile int lastMaxMerges;
+        volatile int lastMaxThreads;
+
+        @Override
+        public void setMaxMergesAndThreads(int maxMerges, int maxThreads) {
+            super.setMaxMergesAndThreads(maxMerges, maxThreads);
+            this.lastMaxMerges = maxMerges;
+            this.lastMaxThreads = maxThreads;
+        }
+    }
+
+    @Before
+    public void setUp() {
+        mgr = MultiTenantCMSManager.getInstance();
+        mgr.unregisterAllForTest();
+    }
+
+    @After
+    public void tearDown() {
+        mgr.unregisterAllForTest();
+    }
+
+    @Test
+    public void testSingleSchedulerGetsFullBudget() {
+        DummyCMS cms = new DummyCMS();
+        mgr.register(cms);
+
+        // exactly one registered
+        Set<ConcurrentMergeScheduler> regs = mgr.getRegisteredSchedulersForTest();
+        assertEquals("should register exactly one", 1, regs.size());
+
+        // compute what the manager should have done
+        int cores          = Runtime.getRuntime().availableProcessors();
+        int maxThreadCount = Math.max(1, cores/2);
+        int share          = Math.max(1, maxThreadCount/1);
+        int merges         = share + 5;
+
+        assertEquals("maxThreads == share",     share,  cms.lastMaxThreads);
+        assertEquals("maxMerges == share + 5",  merges, cms.lastMaxMerges);
+    }
+
+    @Test
+    public void testTwoSchedulersSplitBudgetEqually() {
+        DummyCMS cms1 = new DummyCMS();
+        DummyCMS cms2 = new DummyCMS();
+
+        mgr.register(cms1);
+        mgr.register(cms2);
+
+        Set<ConcurrentMergeScheduler> regs = mgr.getRegisteredSchedulersForTest();
+        assertEquals("should register two", 2, regs.size());
+
+        int cores          = Runtime.getRuntime().availableProcessors();
+        int maxThreadCount = Math.max(1, cores/2);
+        int share          = Math.max(1, maxThreadCount/2);
+        int merges         = share + 5;
+
+        // both should get the same share
+        assertEquals(share,  cms1.lastMaxThreads);
+        assertEquals(merges, cms1.lastMaxMerges);
+
+        assertEquals(share,  cms2.lastMaxThreads);
+        assertEquals(merges, cms2.lastMaxMerges);
+    }
+
+    @Test
+    public void testUnregisterClearsRegistry() {
+        DummyCMS cms = new DummyCMS();
+        mgr.register(cms);
+        assertFalse("registry should not be empty", mgr.getRegisteredSchedulersForTest().isEmpty());
+
+        mgr.unregister(cms);
+        assertTrue("registry should be empty after unregister", mgr.getRegisteredSchedulersForTest().isEmpty());
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiTenantCMSManager.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiTenantCMSManager.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.lucene.index;
 
 import static org.junit.Assert.assertEquals;

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiTenantCMSManager.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiTenantCMSManager.java
@@ -1,6 +1,9 @@
 package org.apache.lucene.index;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 
 import java.util.Set;
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiTenantCMSManager.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiTenantCMSManager.java
@@ -4,97 +4,92 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-
 import java.util.Set;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Smoke-tests MultiTenantCMSManager’s register/unregister + budget math
- */
+/** Smoke-tests MultiTenantCMSManager’s register/unregister + budget math */
 public class TestMultiTenantCMSManager {
 
-    private MultiTenantCMSManager mgr;
+  private MultiTenantCMSManager mgr;
 
-    /**
-     * A dummy CMS that just remembers the last values passed to
-     * setMaxMergesAndThreads(...)
-     */
-    static class DummyCMS extends ConcurrentMergeScheduler {
-        volatile int lastMaxMerges;
-        volatile int lastMaxThreads;
+  /** A dummy CMS that just remembers the last values passed to setMaxMergesAndThreads(...) */
+  static class DummyCMS extends ConcurrentMergeScheduler {
+    volatile int lastMaxMerges;
+    volatile int lastMaxThreads;
 
-        @Override
-        public void setMaxMergesAndThreads(int maxMerges, int maxThreads) {
-            super.setMaxMergesAndThreads(maxMerges, maxThreads);
-            this.lastMaxMerges = maxMerges;
-            this.lastMaxThreads = maxThreads;
-        }
+    @Override
+    public void setMaxMergesAndThreads(int maxMerges, int maxThreads) {
+      super.setMaxMergesAndThreads(maxMerges, maxThreads);
+      this.lastMaxMerges = maxMerges;
+      this.lastMaxThreads = maxThreads;
     }
+  }
 
-    @Before
-    public void setUp() {
-        mgr = MultiTenantCMSManager.getInstance();
-        mgr.unregisterAllForTest();
-    }
+  @Before
+  public void setUp() {
+    mgr = MultiTenantCMSManager.getInstance();
+    mgr.unregisterAllForTest();
+  }
 
-    @After
-    public void tearDown() {
-        mgr.unregisterAllForTest();
-    }
+  @After
+  public void tearDown() {
+    mgr.unregisterAllForTest();
+  }
 
-    @Test
-    public void testSingleSchedulerGetsFullBudget() {
-        DummyCMS cms = new DummyCMS();
-        mgr.register(cms);
+  @Test
+  public void testSingleSchedulerGetsFullBudget() {
+    DummyCMS cms = new DummyCMS();
+    mgr.register(cms);
 
-        // exactly one registered
-        Set<ConcurrentMergeScheduler> regs = mgr.getRegisteredSchedulersForTest();
-        assertEquals("should register exactly one", 1, regs.size());
+    // exactly one registered
+    Set<ConcurrentMergeScheduler> regs = mgr.getRegisteredSchedulersForTest();
+    assertEquals("should register exactly one", 1, regs.size());
 
-        // compute what the manager should have done
-        int cores          = Runtime.getRuntime().availableProcessors();
-        int maxThreadCount = Math.max(1, cores/2);
-        int share          = Math.max(1, maxThreadCount/1);
-        int merges         = share + 5;
+    // compute what the manager should have done
+    int cores = Runtime.getRuntime().availableProcessors();
+    int maxThreadCount = Math.max(1, cores / 2);
+    int share = Math.max(1, maxThreadCount / 1);
+    int merges = share + 5;
 
-        assertEquals("maxThreads == share",     share,  cms.lastMaxThreads);
-        assertEquals("maxMerges == share + 5",  merges, cms.lastMaxMerges);
-    }
+    assertEquals("maxThreads == share", share, cms.lastMaxThreads);
+    assertEquals("maxMerges == share + 5", merges, cms.lastMaxMerges);
+  }
 
-    @Test
-    public void testTwoSchedulersSplitBudgetEqually() {
-        DummyCMS cms1 = new DummyCMS();
-        DummyCMS cms2 = new DummyCMS();
+  @Test
+  public void testTwoSchedulersSplitBudgetEqually() {
+    DummyCMS cms1 = new DummyCMS();
+    DummyCMS cms2 = new DummyCMS();
 
-        mgr.register(cms1);
-        mgr.register(cms2);
+    mgr.register(cms1);
+    mgr.register(cms2);
 
-        Set<ConcurrentMergeScheduler> regs = mgr.getRegisteredSchedulersForTest();
-        assertEquals("should register two", 2, regs.size());
+    Set<ConcurrentMergeScheduler> regs = mgr.getRegisteredSchedulersForTest();
+    assertEquals("should register two", 2, regs.size());
 
-        int cores          = Runtime.getRuntime().availableProcessors();
-        int maxThreadCount = Math.max(1, cores/2);
-        int share          = Math.max(1, maxThreadCount/2);
-        int merges         = share + 5;
+    int cores = Runtime.getRuntime().availableProcessors();
+    int maxThreadCount = Math.max(1, cores / 2);
+    int share = Math.max(1, maxThreadCount / 2);
+    int merges = share + 5;
 
-        // both should get the same share
-        assertEquals(share,  cms1.lastMaxThreads);
-        assertEquals(merges, cms1.lastMaxMerges);
+    // both should get the same share
+    assertEquals(share, cms1.lastMaxThreads);
+    assertEquals(merges, cms1.lastMaxMerges);
 
-        assertEquals(share,  cms2.lastMaxThreads);
-        assertEquals(merges, cms2.lastMaxMerges);
-    }
+    assertEquals(share, cms2.lastMaxThreads);
+    assertEquals(merges, cms2.lastMaxMerges);
+  }
 
-    @Test
-    public void testUnregisterClearsRegistry() {
-        DummyCMS cms = new DummyCMS();
-        mgr.register(cms);
-        assertFalse("registry should not be empty", mgr.getRegisteredSchedulersForTest().isEmpty());
+  @Test
+  public void testUnregisterClearsRegistry() {
+    DummyCMS cms = new DummyCMS();
+    mgr.register(cms);
+    assertFalse("registry should not be empty", mgr.getRegisteredSchedulersForTest().isEmpty());
 
-        mgr.unregister(cms);
-        assertTrue("registry should be empty after unregister", mgr.getRegisteredSchedulersForTest().isEmpty());
-    }
+    mgr.unregister(cms);
+    assertTrue(
+        "registry should be empty after unregister",
+        mgr.getRegisteredSchedulersForTest().isEmpty());
+  }
 }


### PR DESCRIPTION
This pull request introduces the initial working version of MultiTenantCMSManager, which is designed to coordinate merge thread allocation across multiple ConcurrentMergeScheduler (CMS) instances. The manager is implemented as a singleton and currently supports registering and unregistering CMS instances, along with evenly dividing available threads among them. A basic test suite is included using a DummyCMS class to verify that a single scheduler receives the full thread budget and that two schedulers split the budget equally. Tests also confirm that unregistration properly clears the internal state. The CMS now registers and unregisters itself with the manager during initialization and closing. The next steps are to track per-CMS merge state (such as active and pending merges), implement dynamic thread rebalancing based on load, and integrate merge coordination logic into merge() by consulting the manager for stalling and thread assignment. Eventually, legacy fields in ConcurrentMergeScheduler related to thread count and stalling will be removed. The current logic uses equal division but will later be extended to account for merge size, I/O bottlenecks, and other dynamic factors