### PR TITLE
A simplistic MultiTenantCMSManager implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ __pycache__
 
 # SDKMAN
 .sdkmanrc
+
+**/bin/

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -116,7 +116,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
   protected CachedExecutor intraMergeExecutor;
 
   /** Sole constructor, with all settings set to default values. */
-  public ConcurrentMergeScheduler() {}
+  public ConcurrentMergeScheduler() {
+    MultiTenantCMSManager.getInstance().register(this);
+  }
 
   /**
    * Expert: directly set the maximum number of merge threads and simultaneous merges allowed.
@@ -472,6 +474,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
       if (intraMergeExecutor != null) {
         intraMergeExecutor.shutdown();
       }
+      MultiTenantCMSManager.getInstance().unregister(this);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTenantCMSManager.java
@@ -1,0 +1,42 @@
+package org.apache.lucene.index;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Simple demonstration of a MultiTenantCMSManager that divides a fixed thread budget equally among
+ * all registered CMSs.
+ */
+public class MultiTenantCMSManager {
+  private static final MultiTenantCMSManager INSTANCE = new MultiTenantCMSManager();
+  private static final int coreCount = Runtime.getRuntime().availableProcessors();
+  private static final int total_threads = maxThreadCount = Math.max(1, coreCount / 2);
+  private final Set<ConcurrentMergeScheduler> schedulers =
+      Collections.synchronizedSet(new HashSet<>());
+
+  private MultiTenantCMSManager() {}
+
+  public static MultiTenantCMSManager getInstance() {
+    return INSTANCE;
+  }
+
+  public void register(ConcurrentMergeScheduler cms) {
+    schedulers.add(cms);
+    updateBudgets();
+  }
+
+  public void unregister(ConcurrentMergeScheduler cms) {
+    schedulers.remove(cms);
+    updateBudgets();
+  }
+
+  private void updateBudgets() {
+    int count = schedulers.size();
+    if (count == 0) return;
+    int share = Math.max(1, total_threads / count);
+    for (ConcurrentMergeScheduler cms : schedulers) {
+      cms.setMaxMergesAndThreads(share + 5, share);
+    }
+  }
+}


### PR DESCRIPTION
This currently divides available threads evenly across all registered ConcurrentMergeScheduler objects.